### PR TITLE
feat: add /init command to generate QWEN.md project guide

### DIFF
--- a/packages/cli/src/services/CommandService.ts
+++ b/packages/cli/src/services/CommandService.ts
@@ -12,12 +12,14 @@ import { authCommand } from '../ui/commands/authCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
 import { aboutCommand } from '../ui/commands/aboutCommand.js';
+import { initCommand } from '../ui/commands/initCommand.js';
 
 const loadBuiltInCommands = async (): Promise<SlashCommand[]> => [
   aboutCommand,
   authCommand,
   clearCommand,
   helpCommand,
+  initCommand,
   memoryCommand,
   privacyCommand,
   themeCommand,

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SlashCommand } from './types.js';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export const initCommand: SlashCommand = {
+  name: 'init',
+  description: 'create QWEN.md project guide',
+  action: async (context, args) => {
+    const { config } = context.services;
+
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Configuration not available.',
+      };
+    }
+
+    const projectRoot = config.getProjectRoot();
+    const qwenMdPath = path.join(projectRoot, 'QWEN.md');
+
+    // Check if QWEN.md already exists
+    let fileExists = false;
+    try {
+      await fs.access(qwenMdPath);
+      fileExists = true;
+    } catch {
+      // File doesn't exist, continue
+    }
+
+    if (fileExists && !args.includes('--force')) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: 'QWEN.md already exists. Use "/init --force" to overwrite it.',
+      };
+    }
+
+    // Return a query action that will automatically send the prompt
+    return {
+      type: 'query',
+      query: `Please analyze the project structure and create a comprehensive QWEN.md file that provides guidance for AI assistants working with this project.
+
+You have access to these tools:
+- **list_directory**: List files and folders in a directory
+- **glob**: Find files matching patterns (e.g., "**/*.json", "packages/*/src/**/*.ts")
+- **search_file_content**: Search for text patterns in files (grep)
+- **read_file**: Read the contents of a file
+- **read_many_files**: Read multiple files at once
+- **run_shell_command**: Execute shell commands like find, ls, etc.
+- **write_file**: Create or overwrite a file with content
+
+IMPORTANT: Follow these steps in order:
+
+1. **First, discover the project structure:**
+   - Use 'list_directory' to explore the root directory
+   - Use 'run_shell_command' with commands like 'find . -type f -name "*.json" | head -20' to find configuration files
+   - Use 'search_file_content' to search for key patterns like "build", "test", "lint" in package.json files
+   - Use 'glob' to find all package.json files, README files, and documentation (e.g., "**/*.md", "**/package.json")
+
+2. **Then, analyze what you found:**
+   - Use 'read_file' on README.md and any other documentation files
+   - Use 'read_many_files' to read all package.json files at once
+   - Look for configuration files (tsconfig.json, eslint configs, prettier configs)
+   - Check if CLAUDE.md exists and read it to understand the expected format
+
+3. **Explore the codebase architecture:**
+   - Use 'search_file_content' to find main entry points, exports, and key patterns
+   - Use 'read_file' on the main source files you discovered
+   - Use 'glob' to understand the folder structure (e.g., "packages/*/src/**/*.ts")
+
+4. **Finally, create QWEN.md with these sections:**
+   - **Project Overview**: Brief description based on what you learned
+   - **Architecture**: Key architectural patterns and structure
+   - **Development Commands**: All npm scripts found in package.json files
+   - **Code Style Guidelines**: Based on eslint/prettier configs and observed patterns
+   - **Testing Requirements**: Based on test scripts and test file patterns
+   - **Important Notes**: Any special considerations you discovered
+
+Use 'write_file' to create QWEN.md in the project root with all your findings.`,
+    };
+  },
+};

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -69,10 +69,19 @@ export interface OpenDialogActionReturn {
   dialog: 'help' | 'auth' | 'theme' | 'privacy';
 }
 
+/**
+ * The return type for a command action that needs to submit a query to the AI.
+ */
+export interface SubmitQueryActionReturn {
+  type: 'query';
+  query: string;
+}
+
 export type SlashCommandActionReturn =
   | ToolActionReturn
   | MessageActionReturn
-  | OpenDialogActionReturn;
+  | OpenDialogActionReturn
+  | SubmitQueryActionReturn;
 // The standardized contract for any command in the system.
 export interface SlashCommand {
   name: string;

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -1100,6 +1100,11 @@ export const useSlashCommandProcessor = (
                     );
                   }
                 }
+              case 'query':
+                return {
+                  type: 'submit_query',
+                  query: result.query,
+                };
               default: {
                 const unhandled: never = result;
                 throw new Error(`Unhandled slash command result: ${unhandled}`);

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -249,6 +249,15 @@ export const useGeminiStream = (
               prompt_id,
             };
             scheduleToolCalls([toolCallRequest], abortSignal);
+            return { queryToSend: null, shouldProceed: false };
+          } else if (slashCommandResult.type === 'submit_query') {
+            // Add the query as a user message and proceed to send it
+            addItem(
+              { type: MessageType.USER, text: slashCommandResult.query },
+              userMessageTimestamp,
+            );
+            localQueryToSendToGemini = slashCommandResult.query;
+            return { queryToSend: localQueryToSendToGemini, shouldProceed: true };
           }
 
           return { queryToSend: null, shouldProceed: false };

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -228,4 +228,8 @@ export type SlashCommandProcessorResult =
     }
   | {
       type: 'handled'; // Indicates the command was processed and no further action is needed.
+    }
+  | {
+      type: 'submit_query'; // Submit a query to the AI
+      query: string;
     };


### PR DESCRIPTION
## TLDR

This PR adds a new `/init` slash command that automatically explores the codebase and generates a QWEN.md file with project guidance for AI assistants. The command extends the existing command system to support automatic query submission to the LLM.

## Dive Deeper

### What's New
- **New `/init` command**: Generates project documentation by exploring the codebase
- **Extended command system**: Added support for commands that automatically submit queries to the AI
- **Systematic exploration**: Provides explicit instructions for using available tools to analyze the project

### Implementation Details
1. Added `SubmitQueryActionReturn` type to allow commands to queue prompts
2. Extended `SlashCommandProcessorResult` with `submit_query` type
3. Updated `useGeminiStream` hook to handle query submissions
4. Created `initCommand` that checks for existing QWEN.md and sends exploration prompt

### Key Features
- Checks if QWEN.md already exists (use `--force` to overwrite)
- Lists all available tools with their exact names
- Provides step-by-step exploration instructions
- Automatically triggers AI to create comprehensive documentation

## Reviewer Test Plan

1. Build the project: `npm run build`
2. Start the CLI: `npm start`
3. Run the `/init` command
4. Observe the AI exploring the codebase using various tools
5. Verify QWEN.md is created with comprehensive project documentation
6. Test overwrite protection by running `/init` again
7. Test force overwrite with `/init --force`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A - This is a new feature addition